### PR TITLE
[TEST] print: Do not assume that guess_mimetype() can correctly detec…

### DIFF
--- a/addons/print/tests/test_print_printer.py
+++ b/addons/print/tests/test_print_printer.py
@@ -10,6 +10,8 @@ from odoo.tools.mimetypes import guess_mimetype
 from odoo.tests import common
 
 MOCK_LPR = 'MOCK_LPR'
+HTML_MIMETYPE = guess_mimetype(b'<html><body></body></html>')
+XML_MIMETYPE = guess_mimetype(b'<?xml version="1.0"/>')
 
 
 @common.at_install(False)
@@ -209,10 +211,10 @@ class TestPrintPrinter(common.SavepointCase):
         report.report_type = 'qweb-html'
         Printer = self.env['print.printer']
         Printer.spool_test_page()
-        self.assertPrintedLpr('-T', ANY, mimetype='text/html')
+        self.assertPrintedLpr('-T', ANY, mimetype=HTML_MIMETYPE)
 
     def test16_cpcl(self):
         """Test generating CPCL/XML data"""
         self.printer_default.spool_report(self.printer_default.ids,
                                           'print.action_report_test_page_cpcl')
-        self.assertPrintedLpr('-T', ANY, mimetype='text/xml')
+        self.assertPrintedLpr('-T', ANY, mimetype=XML_MIMETYPE)


### PR DESCRIPTION
…t XML

The fallback guess_mimetype() implementation in Odoo (used if the
"magic" module is not installed) is not capable of detecting the
text/xml MIME type, and will therefore misdetect CPCL/XML as
application/octet-stream.

Fix by comparing the detected MIME type for CPCL/XML against the
result of

    guess_mimetype(b'<?xml version="1.0"/>')

Reported-by: Alessandro Parisi <alessandro.parisi@unipart.io>
Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>