### PR TITLE
[IMP] print: Allow passing an ir.actions.report record to spool_report()

### DIFF
--- a/addons/print/models/print_printer.py
+++ b/addons/print/models/print_printer.py
@@ -92,17 +92,21 @@ class Printer(models.Model):
         # pylint: disable=too-many-arguments
 
         # Generate report
-        Report = self.env['ir.actions.report']
-        report = Report._get_report_from_name(report_name)
-        if not report:
-            report = self.env.ref(report_name, raise_if_not_found=False)
-        if not report:
-            raise UserError(_("Undefined report %s") % report_name)
+        if isinstance(report_name, models.BaseModel):
+            report = report_name
+        else:
+            name = report_name
+            Report = self.env['ir.actions.report']
+            report = Report._get_report_from_name(name)
+            if not report:
+                report = self.env.ref(name, raise_if_not_found=False)
+            if not report:
+                raise UserError(_("Undefined report %s") % name)
         document = report.render(docids, data)[0]
 
         # Use report name and document IDs as title if no title specified
         if title is None:
-            title = ("%s %s" % (report_name, str(docids)))
+            title = ("%s %s" % (report.name, str(docids)))
 
         # Spool generated report to printer(s)
         self.spool(document, title=title, copies=copies)

--- a/addons/print/tests/test_print_printer.py
+++ b/addons/print/tests/test_print_printer.py
@@ -161,3 +161,9 @@ class TestPrintPrinter(PrinterCase):
         report = self.env.ref(xmlid)
         cpcl = report.render(self.printer_dotmatrix.ids)[0]
         self.assertCpclReport(cpcl, 'dotmatrix_test_page.xml')
+
+    def test17_spool_by_record(self):
+        """Test spooling ir.actions.report record (rather than report name)"""
+        report = self.env.ref('print.action_report_test_page')
+        self.printer_default.spool_report(self.printer_default.ids, report)
+        self.assertPrintedLpr('-T', ANY)


### PR DESCRIPTION
Some callers may already have an ir.actions.report record, rather than
the report name or XML ID.  Allow the caller to pass in an
ir.actions.report (or compatible) recordset object, rather than
forcing the caller to pass in the report name.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>