### PR TITLE
[IMP] print: Add concept of a printer group

### DIFF
--- a/addons/print/models/print_printer.py
+++ b/addons/print/models/print_printer.py
@@ -6,7 +6,7 @@ import subprocess
 from odoo import api, fields, models
 from odoo.tools.translate import _
 from odoo.tools.misc import find_in_path
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -25,35 +25,93 @@ class Printer(models.Model):
 
     _name = 'print.printer'
     _description = 'Printer'
+    _parent_name = 'group_id'
+    _order = 'parent_left, name'
+    _parent_store = True
+    _parent_order = 'name'
+    _rec_name = 'full_name'
 
     name = fields.Char(string="Name", index=True, required=True)
+    full_name = fields.Char(string="Full Name", compute='_compute_full_name',
+                            store=True, index=True)
     barcode = fields.Char(string="Barcode", index=True)
     queue = fields.Char(string="Print Queue Name", index=True)
     is_default = fields.Boolean(string="System Default", index=True,
                                 default=False)
+    is_group = fields.Boolean(string="Printer Group", default=False)
+    group_id = fields.Many2one('print.printer', string="Printer Group",
+                               index=True, ondelete='cascade',
+                               domain=[('is_group', '=', True)])
+    child_ids = fields.One2many('print.printer', 'group_id',
+                                string="Grouped Printers")
+    parent_left = fields.Integer(string="Left parent", index=True)
+    parent_right = fields.Integer(string="Right parent", index=True)
 
-    _sql_constraints = [('barcode_uniq', 'unique (barcode)',
-                         "The Barcode must be unique"),
-                        ('single_default',
-                         'exclude (is_default with =) where (is_default)',
-                         "There must be only one System Default Printer")]
+    _sql_constraints = [
+        ('barcode_uniq', 'unique (barcode)', "The Barcode must be unique"),
+        ('single_default',
+         'exclude (is_default with =) where (is_default and group_id is null)',
+         "There must be only one System Default Printer"),
+        ('single_group_default',
+         'exclude (group_id with =) where (is_default)',
+         "There must be only one System Default Printer per group"),
+    ]
 
-    def _printers(self):
+    @api.multi
+    @api.depends('name', 'group_id.full_name')
+    def _compute_full_name(self):
+        """Calculate full name (including group name(s))"""
+        for printer in self:
+            if printer.group_id.full_name:
+                printer.full_name = '%s / %s' % (
+                    printer.group_id.full_name, printer.name
+                )
+            else:
+                printer.full_name = printer.name
+
+    @api.multi
+    @api.constrains('is_group', 'group_id', 'child_ids')
+    def _check_groups(self):
+        """Constrain group existence"""
+        for printer in self:
+            if printer.group_id and not printer.group_id.is_group:
+                raise ValidationError(_("%s is not a printer group") %
+                                      printer.group_id.name)
+            if printer.child_ids and not printer.is_group:
+                raise ValidationError(_("%s is not a printer group") %
+                                      printer.name)
+
+    @api.multi
+    def printers(self, raise_if_not_found=False):
         """Determine printers to use"""
 
-        # Use explicitly specified list of printers, falling back to
-        # user's default printer, falling back to system default
-        # printer
+        # Start with explicitly specified list of printers, falling
+        # back to user's default printer, falling back to system
+        # default printer
         printers = (self or self.env.user.printer_id or
-                    self.search([('is_default', '=', True)]))
-        if not printers:
+                    self.search([('is_default', '=', True),
+                                 ('group_id', '=', False)]))
+
+        # Iteratively reduce any printer groups to their user or
+        # system default printers
+        while printers.filtered(lambda x: x.is_group):
+            printers = printers.mapped(lambda p: (
+                p if not p.is_group else
+                ((p.child_ids & self.env.user.printer_ids) or
+                 (p.child_ids.filtered(lambda x: x.is_default)))
+            ))
+
+        # Fail if no printers were found, if applicable
+        if raise_if_not_found and not printers:
             raise UserError(_("No default printer specified"))
+
         return printers
 
+    @api.multi
     def _spool_lpr(self, document, title=None, copies=1):
         """Spool document to printer via lpr"""
         lpr_exec = _find_lpr_exec()
-        for printer in self._printers():
+        for printer in self.printers(raise_if_not_found=True):
 
             # Construct lpr command line
             args = [lpr_exec]
@@ -115,22 +173,29 @@ class Printer(models.Model):
     @api.multi
     def spool_test_page(self):
         """Print test page"""
-        for printer in self._printers():
+        for printer in self.printers(raise_if_not_found=True):
             printer.spool_report(printer.ids, 'print.report_test_page',
                                  title="Test page")
         return True
 
     @api.multi
     def set_user_default(self):
-        """Set as user default printer"""
+        """Set as user default printer (within group, if applicable)"""
         self.ensure_one()
-        self.env.user.printer_id = self
+        user = self.env.user
+        user.printer_ids -= user.printer_ids.filtered(
+            lambda x: x.group_id == self.group_id
+        )
+        user.printer_ids += self
         return True
 
     @api.multi
     def set_system_default(self):
-        """Set as system default printer"""
+        """Set as system default printer (within group, if applicable)"""
         self.ensure_one()
-        self.search([('is_default', '=', True)]).write({'is_default': False})
+        self.search([
+            ('is_default', '=', True),
+            ('group_id', '=', self.group_id.id)
+        ]).write({'is_default': False})
         self.is_default = True
         return True

--- a/addons/print/models/res_users.py
+++ b/addons/print/models/res_users.py
@@ -1,6 +1,8 @@
 """User printing preferences"""
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.tools.translate import _
+from odoo.exceptions import ValidationError
 
 
 class User(models.Model):
@@ -8,4 +10,26 @@ class User(models.Model):
 
     _inherit = 'res.users'
 
-    printer_id = fields.Many2one('print.printer', "Default Printer")
+    printer_ids = fields.Many2many('print.printer', string="Default Printers")
+    printer_id = fields.Many2one('print.printer', string="Default Printer",
+                                 compute='_compute_printer_id', store=True)
+
+    @api.multi
+    @api.depends('printer_ids')
+    def _compute_printer_id(self):
+        """Compute default ungrouped printer (for backwards compatibility)"""
+        for user in self:
+            user.printer_id = user.printer_ids.filtered(
+                lambda x: not x.group_id
+            )
+
+    @api.multi
+    @api.constrains('printer_ids')
+    def _check_printer_ids(self):
+        """Constrain user to having one default printer per group"""
+        for user in self:
+            groups = set(x.group_id for x in user.printer_ids)
+            if len(user.printer_ids) != len(groups):
+                raise ValidationError(_(
+                    "User may have at most one default printer per group"
+                ))

--- a/addons/print/tests/test_print_printer.py
+++ b/addons/print/tests/test_print_printer.py
@@ -102,11 +102,17 @@ class TestPrintPrinter(PrinterCase):
         Printer.sudo(self.user_bob).spool_test_page()
         self.assertPrintedLpr('-T', ANY)
         self.printer_dotmatrix.sudo(self.user_alice).set_user_default()
+        self.assertTrue(
+            self.printer_dotmatrix.sudo(self.user_alice).is_user_default
+        )
         self.assertIn(self.printer_dotmatrix, self.user_alice.printer_ids)
         self.assertEqual(self.user_alice.printer_id, self.printer_dotmatrix)
         self.assertEqual(Printer.sudo(self.user_alice).printers(),
                          self.printer_dotmatrix)
         self.printer_plotter.sudo(self.user_bob).set_user_default()
+        self.assertTrue(
+            self.printer_plotter.sudo(self.user_bob).is_user_default
+        )
         self.assertIn(self.printer_plotter, self.user_bob.printer_ids)
         self.assertEqual(self.user_bob.printer_id, self.printer_plotter)
         self.assertEqual(Printer.sudo(self.user_bob).printers(),

--- a/addons/print/views/print_printer_views.xml
+++ b/addons/print/views/print_printer_views.xml
@@ -23,16 +23,27 @@
 	      <h1>
 		<field name="name" placeholder="e.g. Label printer"/>
 	      </h1>
+	      <label for="group_id" class="oe_edit_only"/>
+	      <h2>
+		<field name="group_id" options="{'no_create': True}"/>
+	      </h2>
 	    </div>
 	    <group>
 	      <group name="properties" string="System Properties">
 		<field name="queue"/>
 		<field name="is_default"/>
+		<field name="is_group"/>
 	      </group>
 	      <group name="identity" string="Identification">
 		<field name="barcode"/>
 	      </group>
 	    </group>
+	    <notebook attrs="{'invisible':[('is_group','=',False)]}">
+	      <page string="Grouped Printers">
+		<field name="child_ids"
+		       context="{'default_group_id': active_id}"/>
+	      </page>
+	    </notebook>
 	  </sheet>
 	</form>
       </field>
@@ -44,7 +55,7 @@
       <field name="model">print.printer</field>
       <field name="arch" type="xml">
 	<tree string="Printers">
-	  <field name="name"/>
+	  <field name="full_name"/>
 	  <field name="queue"/>
 	  <field name="barcode"/>
 	</tree>
@@ -58,17 +69,20 @@
       <field name="arch" type="xml">
 	<search string="Search Printer">
 	  <field name="name" string="Printer"
-		 filter_domain="['|','|',('name','ilike',self),
+		 filter_domain="['|','|',('full_name','ilike',self),
 					 ('queue','ilike',self),
 					 ('barcode','=',self)]"/>
 	  <field name="queue"/>
-	  <group string='Filters'>
+	  <field name="group_id"/>
+	  <group string="Filters">
 	    <filter name="is_default" string="Is System Default Printer"
 		    domain="[('is_default', '=', 'True')]"/>
 	  </group>
-	  <group string='Group by...'>
+	  <group string="Group by...">
 	    <filter name="by_queue" string="Queue" domain="[]"
 		    context="{'group_by':'queue'}"/>
+	    <filter name="by_group_id" string="Printer Group" domain="[]"
+		    context="{'group_by':'group_id'}"/>
 	  </group>
 	</search>
       </field>

--- a/addons/print/views/print_printer_views.xml
+++ b/addons/print/views/print_printer_views.xml
@@ -42,7 +42,7 @@
 		<field name="queue"/>
 		<field name="is_default" readonly="1"/>
 		<field name="is_user_default"/>
-		<field name="is_group"/>
+		<field name="is_group" invisible="1"/>
 	      </group>
 	      <group name="identity" string="Identification">
 		<field name="barcode"/>
@@ -87,8 +87,8 @@
 	  <field name="queue"/>
 	  <field name="group_id"/>
 	  <group string="Filters">
-	    <filter name="is_default" string="Is System Default Printer"
-		    domain="[('is_default', '=', 'True')]"/>
+	    <filter name="is_default" string="Is System Default"
+		    domain="[('is_default', '=', True)]"/>
 	  </group>
 	  <group string="Group by...">
 	    <filter name="by_queue" string="Queue" domain="[]"
@@ -100,13 +100,14 @@
       </field>
     </record>
 
-    <!-- Action window -->
-    <record id="printer_action" model="ir.actions.act_window">
+    <!-- Action window (printers) -->
+    <record id="printer_printer_action" model="ir.actions.act_window">
       <field name="name">Printers</field>
       <field name="type">ir.actions.act_window</field>
       <field name="res_model">print.printer</field>
       <field name="view_type">form</field>
       <field name="view_id" ref="printer_tree"/>
+      <field name="domain">[('is_group', '=', False)]</field>
       <field name="search_view_id" ref="printer_search"/>
       <field name="help" type="html">
 	<p class="oe_view_nocontent_create">
@@ -119,9 +120,34 @@
       </field>
     </record>
 
-    <!-- Menu item -->
-    <menuitem id="printer_menu" action="printer_action"
+    <!-- Action window (groups) -->
+    <record id="printer_group_action" model="ir.actions.act_window">
+      <field name="name">Groups</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="res_model">print.printer</field>
+      <field name="view_type">form</field>
+      <field name="view_id" ref="printer_tree"/>
+      <field name="context">{'default_is_group': True}</field>
+      <field name="domain">[('is_group', '=', True)]</field>
+      <field name="search_view_id" ref="printer_search"/>
+      <field name="help" type="html">
+	<p class="oe_view_nocontent_create">
+	  Click to create a Printer Group.
+	</p>
+	<p>
+	  Backend processes may print documents and reports directly
+	  to printers connected to the Odoo server.
+	</p>
+      </field>
+    </record>
+
+    <!-- Menu items -->
+    <menuitem id="printer_menu" name="Printing"
 	      parent="base.menu_administration" sequence="10"/>
+    <menuitem id="printer_printer_menu" action="printer_printer_action"
+	      parent="printer_menu" sequence="10"/>
+    <menuitem id="printer_group_menu" action="printer_group_action"
+	      parent="printer_menu" sequence="20"/>
 
   </data>
 </odoo>

--- a/addons/print/views/print_printer_views.xml
+++ b/addons/print/views/print_printer_views.xml
@@ -12,10 +12,19 @@
 	    <button name="spool_test_page" type="object" class="oe_highlight"
 		    string="Print Test Page"/>
 	    <button name="set_user_default" type="object"
-		    string="Set as User Default Printer"/>
+		    string="Set as User Default Printer"
+		    attrs="{'invisible':[('is_user_default','=',True)]}"/>
+	    <button name="clear_user_default" type="object" class="btn-danger"
+		    string="Clear as User Default Printer"
+		    attrs="{'invisible':[('is_user_default','=',False)]}"/>
 	    <button name="set_system_default" type="object"
 		    string="Set as System Default Printer"
-		    groups="base.group_system"/>
+		    groups="base.group_system"
+		    attrs="{'invisible':[('is_default','=',True)]}"/>
+	    <button name="clear_system_default" type="object" class="btn-danger"
+		    string="Clear as System Default Printer"
+		    groups="base.group_system"
+		    attrs="{'invisible':[('is_default','=',False)]}"/>
 	  </header>
 	  <sheet>
 	    <div class="oe_title">
@@ -31,7 +40,8 @@
 	    <group>
 	      <group name="properties" string="System Properties">
 		<field name="queue"/>
-		<field name="is_default"/>
+		<field name="is_default" readonly="1"/>
+		<field name="is_user_default"/>
 		<field name="is_group"/>
 	      </group>
 	      <group name="identity" string="Identification">
@@ -54,10 +64,12 @@
       <field name="name">print.printer.tree</field>
       <field name="model">print.printer</field>
       <field name="arch" type="xml">
-	<tree string="Printers">
+	<tree string="Printers" decoration-bf="is_default or is_user_default">
 	  <field name="full_name"/>
 	  <field name="queue"/>
 	  <field name="barcode"/>
+	  <field name="is_default"/>
+	  <field name="is_user_default"/>
 	</tree>
       </field>
     </record>

--- a/addons/print/views/res_users_views.xml
+++ b/addons/print/views/res_users_views.xml
@@ -9,7 +9,7 @@
       <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
       <field name="arch" type="xml">
 	<xpath expr="//group[@name='preferences']" position="inside">
-	  <field name="printer_id"/>
+	  <field name="printer_ids" widget="many2many_tags"/>
 	</xpath>
       </field>
     </record>
@@ -22,7 +22,7 @@
       <field name="arch" type="xml">
 	<xpath expr="//group[@name='messaging']" position="after">
 	  <group name="printing" string="Printing">
-	    <field name="printer_id"/>
+	    <field name="printer_ids" widget="many2many_tags"/>
 	  </group>
 	</xpath>
       </field>


### PR DESCRIPTION
Add the standard Odoo parent/child model to print.printer, allowing
for the concept of a group of printers.  Define both per-user and
system-wide default printers on a per-group basis.

This allows callers to print to a printer group: the actual printer
selected will be based upon the user (or system) default printer
within that group.  This can be used to model a situation in which a
user requires multiple concepts of "default printer": for example, a
warehouse worker may need to have standard A4 PDF delivery slips
printed on an office laser printer but to have 4x4" labels printed on
a mobile Zebra direct thermal printer.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>