### PR TITLE
[IMP] print: Allow automatic selection of report type for a printer

### DIFF
--- a/addons/print/tests/common.py
+++ b/addons/print/tests/common.py
@@ -14,6 +14,7 @@ from odoo.tests import common
 MOCK_LPR = 'MOCK_LPR'
 HTML_MIMETYPE = guess_mimetype(b'<html><body></body></html>')
 XML_MIMETYPE = guess_mimetype(b'<?xml version="1.0"/>')
+PDF_MIMETYPE = 'application/pdf'
 
 
 @common.at_install(False)

--- a/addons/print/views/print_printer_views.xml
+++ b/addons/print/views/print_printer_views.xml
@@ -40,6 +40,7 @@
 	    <group>
 	      <group name="properties" string="System Properties">
 		<field name="queue"/>
+		<field name="report_type"/>
 		<field name="is_default" readonly="1"/>
 		<field name="is_user_default"/>
 		<field name="is_group" invisible="1"/>
@@ -67,6 +68,7 @@
 	<tree string="Printers" decoration-bf="is_default or is_user_default">
 	  <field name="full_name"/>
 	  <field name="queue"/>
+	  <field name="report_type"/>
 	  <field name="barcode"/>
 	  <field name="is_default"/>
 	  <field name="is_user_default"/>
@@ -86,6 +88,7 @@
 					 ('barcode','=',self)]"/>
 	  <field name="queue"/>
 	  <field name="group_id"/>
+	  <field name="report_type"/>
 	  <group string="Filters">
 	    <filter name="is_default" string="Is System Default"
 		    domain="[('is_default', '=', True)]"/>
@@ -95,6 +98,8 @@
 		    context="{'group_by':'queue'}"/>
 	    <filter name="by_group_id" string="Printer Group" domain="[]"
 		    context="{'group_by':'group_id'}"/>
+	    <filter name="by_report_type" string="Report Type" domain="[]"
+		    context="{'group_by':'report_type'}"/>
 	  </group>
 	</search>
       </field>


### PR DESCRIPTION
Define a report type (e.g. "qweb-pdf" or "qweb-cpcl") for a printer
and allow spool_report() to be called with a recordset of multiple
reports, with the appropriate report being selected automatically for
each printer based on matching the report types.

This allows CPCL/XML test pages to be printed via the standard "Print
Test Page" action.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>