### PR TITLE
[IMP] odoo-print: automated printing

### DIFF
--- a/addons/print/__manifest__.py
+++ b/addons/print/__manifest__.py
@@ -27,6 +27,7 @@ Key Features
         'report/test_page_reports.xml',
         'views/res_users_views.xml',
         'views/print_printer_views.xml',
+        'views/print_strategy_views.xml',
         'data/print_printer_data.xml',
         'data/set_default_printer.yml'
     ],

--- a/addons/print/models/__init__.py
+++ b/addons/print/models/__init__.py
@@ -1,5 +1,6 @@
 """Printing models"""
 
 from . import ir_actions_report
+from . import ir_actions_print
 from . import res_users
 from . import print_printer

--- a/addons/print/models/ir_actions_print.py
+++ b/addons/print/models/ir_actions_print.py
@@ -1,0 +1,119 @@
+"""Print actions."""
+
+import logging
+from odoo import api, fields, models
+from odoo.tools import config
+
+_logger = logging.getLogger(__name__)
+
+class IrActionsPrint(models.Model):
+    """Print actions.
+
+       Odoo actions are like named events. Raised in the context of a modelled
+       object, actions are decoupled from the behaviour to effect when handling
+       the event. Print actions further decouple behaviour by allowing
+       different print strategies to be executed for different modelled objects.
+
+       If the report specified for a print strategy cannot render a document
+       from records selected from the modelled object by the strategy then an
+       error is logged and the strategy is skipped.
+    """
+
+    _inherit = 'ir.actions.server'
+
+    state = fields.Selection(selection_add=[('print', 'Print')])
+
+    # A print action must be configured with a print strategy model. The print
+    # strategies to execute for an object are selected from that model.
+    strategy_id = fields.Many2one('ir.model', 'Print Strategy')
+
+    _sql_constraints = [(
+        'print_strategy',
+        "CHECK (NOT (state = 'print' AND strategy_id IS NULL))",
+        'Print Strategy must be set',
+    )]
+
+    @api.multi
+    def run_action_print(self, action, eval_context=None): # pylint: disable=unused-argument
+        """Print a report using the print strategies for the context object."""
+        # get the context object
+        context = action.env.context
+        active_model = context['active_model']
+        active_id = context['active_id']
+        obj = action.env[active_model].browse(active_id)
+        # execute strategies for printing the object
+        for strategy in self.env[self.strategy_id.model].strategies(obj):
+            _logger.info('executing %s action with strategy %s for %s id %d',
+                         action.state, strategy.name,
+                         active_model, active_id)
+            if not strategy.enabled():
+                continue
+            # the strategy model must produce print strategies
+            printer = strategy.printer_id
+            report = strategy.report_id
+            records = strategy.records(obj)
+            # print
+            printer.spool_report(records.ids, report)
+
+class PrintStrategy(models.Model):
+    """Print strategy.
+
+       The base print strategy is to print the context object using the
+       specified report on the specified printer.
+    """
+    _name = 'print.strategy'
+
+    name = fields.Char(required=True)
+
+    # the report to render for each selected record
+    report_id = fields.Many2one(
+        'ir.actions.report', string='Report',
+        required=True,
+    )
+
+    # the model of context object which this strategy will render
+    model = fields.Char(
+        related='report_id.model',
+        readonly=True,
+    )
+
+    # the printer to print each rendered document with
+    printer_id = fields.Many2one(
+        'print.printer', string='Printer',
+        required=False,
+    )
+
+    # configurable safety catch
+    safety = fields.Char(
+        string='Safety Catch',
+        help="""Configuration file option required for operation.
+
+        If present, this option must have a truthy value within the
+        local configuration file to enable printing using this strategy.
+        """
+    )
+
+    @api.model
+    def strategies(self, obj):
+        """Return the print strategies to use for context `obj`."""
+        return self.search([
+            ('model', '=', obj._name),
+        ])
+
+    @api.multi
+    def enabled(self):
+        """Return True if a print strategy is enabled, False otherwise."""
+        self.ensure_one()
+        if self.safety:
+            section, _sep, key = self.safety.rpartition('.')
+            if not config.get_misc(section or self._name, key):
+                _logger.info('%s %s disabled, enable by configuring safety %s',
+                             self._name, self.name,
+                             '.'.join((section or self._name, key)))
+                return False
+        return True
+
+    @api.multi
+    def records(self, obj):
+        """Return the records to render for context `obj`."""
+        return obj

--- a/addons/print/security/ir.model.access.csv
+++ b/addons/print/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_print_printer_all,print.printer all,model_print_printer,,1,0,0,0
+access_print_strategy,access_print_strategy,model_print_strategy,base.group_user,1,0,0,0

--- a/addons/print/tests/__init__.py
+++ b/addons/print/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_controllers
 from . import test_print_printer
+from . import test_action_print

--- a/addons/print/tests/test_action_print.py
+++ b/addons/print/tests/test_action_print.py
@@ -1,0 +1,123 @@
+"""Printing action tests"""
+
+from unittest.mock import ANY
+
+from psycopg2 import IntegrityError
+
+from odoo.tools import mute_logger
+from .common import PrinterCase
+
+class TestActionPrint(PrinterCase):
+    """Printing action tests"""
+    action_model = 'ir.actions.server'
+
+    @property
+    def default_report(self):
+        """Return the default report"""
+        return self.env.ref('print.action_report_test_page')
+
+    @property
+    def default_printer(self):
+        """Return the default printer"""
+        return self.env.ref('print.default_printer')
+
+    @classmethod
+    def model_id(cls, model):
+        """Return the model id of `model`."""
+        return cls.env['ir.model']._get_id(model)
+
+    def create_action(self, name, model='print.strategy'):
+        """Return new print action with `name` and print strategy `model`."""
+        return self.env[self.action_model].create({
+            'name': name,
+            'model_id': self.model_id(self.action_model),
+            'state': 'print',
+            'strategy_id': self.model_id(model),
+        })
+
+    def create_strategy(self, name, report, printer, safety=None,
+                        model='print.strategy'):
+        """Return new print strategy `model` instance from given args."""
+        return self.env[model].create({
+            'name': name,
+            'report_id': None if report is None else report.id,
+            'printer_id': None if printer is None else printer.id,
+            'safety': safety,
+        })
+
+    def test01_missing_strategy(self):
+        """Test print action must specify strategy_id"""
+        with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+            self.create_action('missing strategy_id', None)
+
+    def test02_no_strategies(self):
+        """Test print action with no strategies"""
+        action = self.create_action('no strategies')
+        # nothing to be printed when the action is run
+        # action may be run in any context: context object is benign
+        action.with_context(
+            active_model=action._name,
+            active_ids=action.ids,
+        ).run()
+        self.mock_subprocess.Popen.assert_not_called()
+
+    def test03_missing_report(self):
+        """Test print strategy must specify report_id"""
+        with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+            self.create_strategy('missing report_id', None, None)
+
+    def test04_missing_printer(self):
+        """Test print strategy may omit printer_id"""
+        self.create_strategy('missing printer_id', self.default_report, None)
+
+    def test05_one_strategy(self):
+        """Test print action with one strategy"""
+        action = self.create_action('one strategy')
+        self.create_strategy('Chesney', self.default_report, None)
+        # nothing to be printed when the action is run in the wrong context
+        action.with_context(
+            active_model=action._name,
+            active_ids=action.ids,
+        ).run()
+        self.mock_subprocess.Popen.assert_not_called()
+        # a single document to be printed when run in the right context
+        printer = self.default_printer
+        action.with_context(
+            active_model=printer._name,
+            active_ids=printer.ids,
+        ).run()
+        self.assertPrintedLpr('-T', ANY)
+
+    def test06_two_strategies(self):
+        """Test print action with two strategies"""
+        action = self.create_action('two strategies')
+        self.create_strategy('Ant', self.default_report, None)
+        self.create_strategy('Dec', self.default_report, None)
+        # nothing to be printed when the action is run in the wrong context
+        action.with_context(
+            active_model=action._name,
+            active_ids=action.ids,
+        ).run()
+        self.mock_subprocess.Popen.assert_not_called()
+        # two documents to be printed when run in the right context
+        printer = self.default_printer
+        action.with_context(
+            active_model=printer._name,
+            active_ids=printer.ids,
+        ).run()
+        self.assertPrintedLprMulti(
+            ('-T', ANY),
+            ('-T', ANY),
+        )
+
+    def test07_safety_catch(self):
+        """Test print strategy disabled by safety catch"""
+        action = self.create_action('safety strategy')
+        self.create_strategy('Test 07', self.default_report, None, 'test07')
+        # nothing to be printed when the safety catch is not disabled
+        printer = self.default_printer
+        action.with_context(
+            active_model=printer._name,
+            active_ids=printer.ids,
+        ).run()
+        self.mock_subprocess.Popen.assert_not_called()

--- a/addons/print/views/print_strategy_views.xml
+++ b/addons/print/views/print_strategy_views.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<odoo>
+  <data>
+
+    <!-- Form view -->
+    <record id="print_strategy_form" model="ir.ui.view">
+      <field name="name">print.strategy.form</field>
+      <field name="model">print.strategy</field>
+      <field name="arch" type="xml">
+        <form string="Print Strategy">
+          <sheet>
+            <div class="oe_title">
+              <label for="name" class="oe_edit_only"/>
+              <h1>
+                <field name="name"/>
+              </h1>
+            </div>
+            <group name="basic">
+              <field name="report_id"/>
+              <field name="printer_id"/>
+              <field name="safety"/>
+            </group>
+          </sheet>
+        </form>
+      </field>
+    </record>
+
+    <!-- Tree view -->
+    <record id="print_strategy_tree" model="ir.ui.view">
+      <field name="name">print.strategy.tree</field>
+      <field name="model">print.strategy</field>
+      <field name="arch" type="xml">
+        <tree string="Print Strategies">
+          <field name="name"/>
+          <field name="report_id"/>
+          <field name="printer_id"/>
+          <field name="safety"/>
+        </tree>
+      </field>
+    </record>
+
+    <!-- Search filter -->
+    <record id="print_strategy_search" model="ir.ui.view">
+      <field name="name">print.strategy.search</field>
+      <field name="model">print.strategy</field>
+      <field name="arch" type="xml">
+        <search string="Search Print Strategies">
+          <field name="name" string="Name"
+                 filter_domain="[('name','ilike',self)]"/>
+          <field name="report_id"/>
+          <field name="printer_id"/>
+          <field name="safety" string="Safety Catch"
+                 filter_domain="[('safety','like',self)]"/>
+          <group string="Group by...">
+            <filter name="by_printer" string="Printer" domain="[]"
+                    context="{'group_by':'printer_id'}"/>
+            <filter name="by_safety" string="Safety Catch" domain="[]"
+                    context="{'group_by':'safety'}"/>
+          </group>
+        </search>
+      </field>
+    </record>
+
+    <!-- Action window (automated print strategy) -->
+    <record id="print_strategy_action" model="ir.actions.act_window">
+      <field name="name">Automated Printing</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="res_model">print.strategy</field>
+      <field name="view_type">form</field>
+      <field name="view_id" ref="print_strategy_tree"/>
+      <field name="search_view_id" ref="print_strategy_search"/>
+      <field name="help" type="html">
+        <p class="oe_view_nocontent">
+          No automated printing strategies are configured.
+        </p>
+      </field>
+    </record>
+
+    <!-- Menu items -->
+    <menuitem id="print_strategy_menu" action="print_strategy_action"
+              parent="printer_menu" sequence="100"/>
+
+  </data>
+</odoo>


### PR DESCRIPTION
Trigger automated printing on running an ir.actions.server print
action. A single action may select any number of print strategies
to run for a context object/record. All print strategies whose
report can render the context object will be executed. A safety
catch (configuration file setting) allows a print strategy or
strategies to be disabled to prevent automatic printing when
undesirable. The web UI presents a read-only view of configured
print strategies; an administrator may edit configured print
strategies.

User-story: 1522
Task: 2082
Signed-off-by: David Spence <david.spence@unipart.io>