### PR TITLE
[TEST] print: Extend test coverage to include the logout controller

### DIFF
--- a/addons/print/tests/__init__.py
+++ b/addons/print/tests/__init__.py
@@ -1,3 +1,4 @@
 """Printing tests"""
 
+from . import test_controllers
 from . import test_print_printer

--- a/addons/print/tests/test_controllers.py
+++ b/addons/print/tests/test_controllers.py
@@ -1,0 +1,49 @@
+"""Printing controller tests"""
+
+from .common import PrinterHttpCase
+
+
+class TestController(PrinterHttpCase):
+    """Printing controller tests"""
+
+    def setUp(self):
+        super().setUp()
+
+        # Create user
+        User = self.env['res.users']
+        self.user_alice = User.create({
+            'name': "Alice",
+            'login': "alice",
+            'password': "password",
+        })
+
+        # Create printers
+        Printer = self.env['print.printer']
+        self.printer_inkjet = Printer.create({
+            'name': "Inkjet",
+            'is_ephemeral': True,
+        })
+        self.printer_laser = Printer.create({
+            'name': "Laser",
+            'is_ephemeral': False,
+        })
+
+    def test01_logout_ephemeral(self):
+        """Test clearing ephemeral printers on logout"""
+        self.authenticate("alice", "password")
+        self.printer_inkjet.sudo(self.user_alice).set_user_default()
+        self.assertIn(self.printer_inkjet, self.user_alice.printer_ids)
+        self.url_open('/web/session/logout')
+        self.assertNotIn(self.printer_inkjet, self.user_alice.printer_ids)
+
+    def test02_logout_non_ephemeral(self):
+        """Test not clearing non-ephemeral printers on logout"""
+        self.authenticate("alice", "password")
+        self.printer_laser.sudo(self.user_alice).set_user_default()
+        self.assertIn(self.printer_laser, self.user_alice.printer_ids)
+        self.url_open('/web/session/logout')
+        self.assertIn(self.printer_laser, self.user_alice.printer_ids)
+
+    def test03_logout_unauthenticated(self):
+        """Test logout from a non-authenticated user"""
+        self.url_open('/web/session/logout')


### PR DESCRIPTION
Extend test coverage to include the logout controller (used to clear
ephemeral user default printers on logout).

Note that some careful cursor and cache management is required to
ensure that changes made within the unit tests are visible within the
separate environment created to handle the HTTP request.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>