### PR TITLE
[IMP] print strategy support for multiple report models

### DIFF
--- a/addons/print/models/ir_actions_print.py
+++ b/addons/print/models/ir_actions_print.py
@@ -51,9 +51,10 @@ class IrActionsPrint(models.Model):
             # the strategy model must produce print strategies
             printer = strategy.printer_id
             report = strategy.report_id
-            records = strategy.records(obj)
+            records = strategy.records(obj, context)
             # print
-            printer.spool_report(records.ids, report)
+            if records is not None:
+                printer.spool_report(records.ids, report)
 
 class PrintStrategy(models.Model):
     """Print strategy.
@@ -114,6 +115,9 @@ class PrintStrategy(models.Model):
         return True
 
     @api.multi
-    def records(self, obj):
-        """Return the records to render for context `obj`."""
+    def records(self, obj, context=None):
+        """Return the records to render for context `obj`
+
+           Return None if this strategy should be skipped
+        """
         return obj


### PR DESCRIPTION
Allow print strategies to select the records to print
based upon the report model. This allows multiple
reports to be printed with different content for the
same context object.

Signed-off-by: David Spence <david.spence@unipart.io>